### PR TITLE
[WIP] Add support for filtering by event ID in GetFixtures, as well as better error handling

### DIFF
--- a/R/GetFixtures.R
+++ b/R/GetFixtures.R
@@ -81,9 +81,22 @@ GetFixtures <-
         expandListColumns() %>%
         as.data.frame()
     } else {
-      # If there is no content, return an empty data frame.
-      # TODO: Give this the correct columns.
-      data.frame()
+      # If there is no content, return a zero-row data frame. This attempts to
+      # set the columns correctly, but may not be future-proof, and does not
+      # include pitchers. Still -- some column names is still much more
+      # informative than no column names at all.
+
+      # Bypass the data.frame() function purely for the 5x speed up on known,
+      # valid columns.
+      structure(list(
+        sportId = integer(), last = integer(), league.id = integer(),
+        league.name = character(), league.events.id = integer(),
+        league.events.starts = character(), league.events.home = character(),
+        league.events.away = character(), league.events.rotNum = character(),
+        league.events.liveStatus = integer(),
+        league.events.status = character(),
+        league.events.parlayRestriction = integer()
+      ), class = "data.frame")
     }
   }
 

--- a/R/GetFixtures.R
+++ b/R/GetFixtures.R
@@ -2,6 +2,7 @@
 #'
 #' @param sportid (optional) an integer giving the sport, if missing, a menu of options is presented
 #' @param leagueids (optional) integer vector with league IDs.
+#' @param eventids (optional) integer vector with event IDs.
 #' @param since (optional) numeric this is used to receive incremental updates.
 #' Use the value of `last` from previous fixtures response.
 #' @param islive Default=FALSE, boolean if TRUE retrieves ONLY live events if FALSE retrieved all events
@@ -35,6 +36,7 @@
 GetFixtures <-
   function(sportid,
            leagueids=NULL,
+           eventids=NULL,
            since=NULL,
            islive=0){
 
@@ -45,18 +47,28 @@ GetFixtures <-
       ViewSports()
       sportid <- readline('Selection (id): ')
     }
-    
-    message(Sys.time(), '| Pulling Fixtures for SportID: ', sportid, 
-            if (!is.null(leagueids)) sprintf(' and leagueIds: %s', leagueids))
-    
+
+    message(Sys.time(), "| Pulling Fixtures for Sport ID: ", sportid,
+            if (!is.null(leagueids)) paste(", with League ID(s):",
+                                           paste(leagueids, collapse = ", ")),
+            if (!is.null(eventids)) paste(", and Event ID(s):",
+                                          paste(eventids, collapse = ", ")))
+
+    # Construct URL parameter list.
+    params <- list(sportId = sportid, since = since,
+                   isLive = as.integer(islive))
+    if (!is.null(leagueids)) {
+      params$leagueIds <- paste(leagueids, collapse = ",")
+    }
+    if (!is.null(eventids)) {
+      params$eventIds <- paste(eventids, collapse = ",")
+    }
+
     r <- 
       sprintf('%s/v1/fixtures', .PinnacleAPI$url) %>%
       GET(add_headers(Authorization = authorization(),
                       "Content-Type" = "application/json"),
-          query = list(sportId = sportid,
-                       leagueIds = if (!is.null(leagueids)) paste(leagueids,collapse = ',') else NULL,
-                       since = since,
-                       isLive = islive*1L)) %>%
+          query = params) %>%
       content(type = "text", encoding = "UTF-8") 
     
     

--- a/R/GetFixtures.R
+++ b/R/GetFixtures.R
@@ -1,6 +1,6 @@
 #' Get Fixtures
 #'
-#' @param sportid (optional) an integer giving the sport, if missing, a menu of options is presented
+#' @param sportid An integer giving the sport. If this is missing in interactive mode, a menu of options is presented to the user.
 #' @param leagueids (optional) integer vector with league IDs.
 #' @param eventids (optional) integer vector with event IDs.
 #' @param since (optional) numeric this is used to receive incremental updates.
@@ -41,11 +41,14 @@ GetFixtures <-
            islive=0){
 
     CheckTermsAndConditions()
-    ## retrieve sportid
-    if(missing(sportid)) {
+
+    # In interactive mode, try to retrieve a missing sportid parameter.
+    if(interactive() && missing(sportid)) {
       cat('No Sports Selected, choose one:\n')
       ViewSports()
       sportid <- readline('Selection (id): ')
+    } else if (missing(sportid)) {
+      stop("missing sport ID")
     }
 
     message(Sys.time(), "| Pulling Fixtures for Sport ID: ", sportid,


### PR DESCRIPTION
This PR adds support for narrowing event queries to the Get Fixtures endpoint by event ID, [as supported by the API](https://pinnacleapi.github.io/#operation/Fixtures_V1_Get).

Along the way, I've tried to improve error handling and improve ergonomics for the larger function, as discussed.