### PR TITLE
Use the new error handling function for all recently added endpoints

### DIFF
--- a/R/GetBettingStatus.R
+++ b/R/GetBettingStatus.R
@@ -30,33 +30,12 @@
 GetBettingStatus <- function() {
   CheckTermsAndConditions()
 
-  request <- httr::GET(paste0(.PinnacleAPI$url, "/v1/bets/betting-status"),
-                       httr::add_headers(Authorization = authorization()),
-                       httr::accept_json())
+  response <- httr::GET(paste0(.PinnacleAPI$url, "/v1/bets/betting-status"),
+                        httr::add_headers(Authorization = authorization()),
+                        httr::accept_json())
 
-  # The API won't return a JSON error code in this case, so bail out before
-  # trying to parse it.
-  if (httr::status_code(request) == 404) {
-    stop("API request returned code 404 (Not Found).")
-  }
+  CheckForAPIErrors(response)
 
-  response <- jsonlite::fromJSON(httr::content(request, type = "text",
-                                               encoding = "UTF-8"))
-  # Error out on non-OK responses.
-  if (httr::status_code(request) == 200) {
-    response$status
-  } else {
-    # Attempt to signal helpful errors.
-    switch(
-      response$code,
-      "INVALID_REQUEST_DATA" = stop("Internal error. Invalid data."),
-      "INVALID_AUTHORIZATION_HEADER" =
-        stop("Internal error. Missing/incomplete auth header."),
-      "INVALID_CREDENTIALS" = stop("Invalid login credentials."),
-      "ACCOUNT_INACTIVE" = stop("Inactive login account."),
-      "NO_API_ACCESS" = stop("Login account does not have API access."),
-      stop(paste0("API error: ", response$message, " (API code: ",
-                  response$code, ")"))
-    )
-  }
+  response <- httr::content(response, type = "text", encoding = "UTF-8")
+  jsonlite::fromJSON(response)$status
 }

--- a/R/PlaceSpecialBet.R
+++ b/R/PlaceSpecialBet.R
@@ -94,27 +94,14 @@ PlaceSpecialBet <- function(stake, lineId, specialId, contestantId,
                      stringsAsFactors = FALSE)
 
   request_body <- jsonlite::toJSON(list(bets = bets), auto_unbox = TRUE)
-  request <- httr::POST(paste0(.PinnacleAPI$url, "/v1/bets/special"),
-                        httr::add_headers(Authorization = authorization(),
-                                          `Content-Type` = "application/json"),
-                        httr::accept_json(),
-                        body = request_body)
-  response <- jsonlite::fromJSON(httr::content(request, type = "text",
-                                               encoding = "UTF-8"))
-  # Error out on non-OK responses.
-  if (httr::status_code(request) == 200) {
-    response$bets
-  } else {
-    # Attempt to signal helpful errors.
-    switch(
-      response$code,
-      "INVALID_REQUEST_DATA" = stop("Internal error. Invalid data."),
-      "INVALID_AUTHORIZATION_HEADER" =
-        stop("Internal error. Missing/incomplete auth header."),
-      "INVALID_CREDENTIALS" = stop("Invalid login credentials."),
-      "ACCOUNT_INACTIVE" = stop("Inactive login account."),
-      "NO_API_ACCESS" = stop("Login account does not have API access."),
-      stop(paste0("API error: ", response$message, " (", response$code, ")"))
-    )
-  }
+  response <- httr::POST(paste0(.PinnacleAPI$url, "/v1/bets/special"),
+                         httr::add_headers(Authorization = authorization(),
+                                           `Content-Type` = "application/json"),
+                         httr::accept_json(),
+                         body = request_body)
+
+  CheckForAPIErrors(response)
+
+  response <- httr::content(response, type = "text", encoding = "UTF-8")
+  jsonlite::fromJSON(response)$bets
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -109,13 +109,16 @@ CheckForAPIErrors <- function(response) {
       response <- response %>%
         httr::content(type = "text", encoding = "UTF-8") %>%
         jsonlite::fromJSON()
-      stop(paste0("API error: ", response$message, " (", response$code, ")"))
+      stop(paste0(response$message,
+                  ifelse(endsWith(response$message, "."), "", "."),
+                  " (code: ", response$code, ")"))
     } else {
       # Give approximate errors when the error does not return JSON.
       switch(as.character(code),
              "400" = stop("Invalid request parameters."),
-             "401" = stop("Invalid login credentials."),
-             "403" = stop("Inactive login account."),
+             "401" = stop("Invalid or missing login credentials."),
+             "403" = stop("Account is inactive or lacks API access."),
+             "500" = stop("Internal API server error."),
              stop("API request returned HTTP code ", code))
     }
   }


### PR DESCRIPTION
This PR updates the endpoint functions introduced in #21 in #22 to use the error handling approach added as part of #26. This dramatically simplifies them in most cases, and since they have not appeared on CRAN yet no one should be affected by the slightly different error messages yet.