### PR TITLE
Improves handling of missing credentials, rejecting T&Cs, and adds the start of a test suite

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,3 +20,4 @@ Imports:
     jsonlite,
     rjson
 RoxygenNote: 6.0.1
+Suggests: testthat, yaml

--- a/R/GetFixtures.R
+++ b/R/GetFixtures.R
@@ -56,6 +56,10 @@ GetFixtures <-
       stop("missing sport ID")
     }
 
+    if (length(sportid) > 1) {
+      stop("Only one sport can be specified at a time.")
+    }
+
     message(Sys.time(), "| Pulling Fixtures for Sport ID: ", sportid,
             if (!is.null(leagueids)) paste(", with League ID(s):",
                                            paste(leagueids, collapse = ", ")),

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,5 @@
+library(testthat)
+library(yaml)
+library(pinnacle.API)
+
+test_check("pinnacle.API")

--- a/tests/testthat/test-basic-functionality.R
+++ b/tests/testthat/test-basic-functionality.R
@@ -48,3 +48,43 @@ testthat::test_that("GetBettingStatus() returns the expected format", {
                                       "ALL_LIVE_BETTING_CLOSED",
                                       "ALL_BETTING_CLOSED"))
 })
+
+# Straight Lines --------------------------------------------------------------
+testthat::context("Straight Lines")
+
+testthat::test_that("GetFixtures() returns the expected format", {
+  fixtures <- pinnacle.API::GetFixtures(config$sport)
+
+  testthat::expect_is(fixtures, "data.frame")
+  testthat::expect_gt(nrow(fixtures), 0)
+
+  # Pick some events to test filtering calls against.
+  set.seed(101)
+  events <- sample.int(nrow(fixtures), 2)
+  events <- fixtures[events, c("league.id", "league.events.id")]
+  names(events) <- c("league", "event")
+
+  result <- pinnacle.API::GetFixtures(config$sport, eventids = events$event)
+  testthat::expect_equal(nrow(result), 2)
+
+  # Mismatched league/event IDs should give no results.
+  result <- pinnacle.API::GetFixtures(config$sport, eventids = events$event[1],
+                                      leagueids = events$league[1] + 1)
+  testthat::expect_equal(nrow(result), 0)
+
+  # Adding an invalid event ID should error.
+  testthat::expect_error(
+    pinnacle.API::GetFixtures(config$sport, eventids = c(-1, events$event)),
+    regexp = "Invalid request parameters."
+  )
+
+  # As should the addition of a second sport.
+  testthat::expect_error(
+    pinnacle.API::GetFixtures(c(config$sport, 1e6), eventids = events$event),
+    regexp = "Only one sport can be specified at a time."
+  )
+
+  # Some odd event IDs are allowed, though.
+  result <- pinnacle.API::GetFixtures(config$sport, eventids = 0)
+  testthat::expect_equal(nrow(result), 0)
+})

--- a/tests/testthat/test-basic-functionality.R
+++ b/tests/testthat/test-basic-functionality.R
@@ -1,0 +1,50 @@
+# Read test server/account parameters from a YAML file, so that they can be
+# kept out of the sources.
+config <- yaml::read_yaml("test_config.yaml")
+
+incomplete_config <- function() {
+  any(sapply(config, is.null))
+}
+
+if (!incomplete_config()) {
+  pinnacle.API::AcceptTermsAndConditions(TRUE)
+  pinnacle.API::SetCredentials(config$username, config$password)
+  pinnacle.API::SetAPIEndpoint(config$url)
+}
+
+# Basic API Functionality -----------------------------------------------------
+testthat::context("Basic API Functionality")
+
+testthat::skip_if(incomplete_config(), "Incomplete test configuration file.")
+
+testthat::test_that("API calls fail when terms are not explicitly accepted", {
+  pinnacle.API::AcceptTermsAndConditions(FALSE)
+  on.exit(pinnacle.API::AcceptTermsAndConditions(TRUE))
+
+  testthat::expect_error(
+    pinnacle.API::AcceptTermsAndConditions("invalid"),
+    regexp = "is not TRUE"
+  )
+
+  testthat::expect_error(
+    pinnacle.API::GetBettingStatus(),
+    regexp = "Error: please accept terms and conditions to continue"
+  )
+})
+
+testthat::test_that("API calls fail on invalid credentials", {
+  pinnacle.API::SetCredentials(config$username, "badpassword")
+  on.exit(pinnacle.API::SetCredentials(config$username, config$password))
+
+  testthat::expect_error(
+    pinnacle.API::GetBettingStatus(),
+    regexp = "Authorization failed, invalid credentials."
+  )
+})
+
+testthat::test_that("GetBettingStatus() returns the expected format", {
+  status <- pinnacle.API::GetBettingStatus()
+  testthat::expect_true(status %in% c("ALL_BETTING_ENABLED",
+                                      "ALL_LIVE_BETTING_CLOSED",
+                                      "ALL_BETTING_CLOSED"))
+})

--- a/tests/testthat/test_config.yaml
+++ b/tests/testthat/test_config.yaml
@@ -1,3 +1,4 @@
 username:
 password:
 url:
+sport:

--- a/tests/testthat/test_config.yaml
+++ b/tests/testthat/test_config.yaml
@@ -1,0 +1,3 @@
+username:
+password:
+url:


### PR DESCRIPTION
This PR adds the start of a test suite, which requires filling out the `test_config.yaml` file. There are some tests for `GetBettingStatus()`, `GetFixtures()`, and `AcceptTermsAndConditions()` included in this first pass.

In the process, I discovered some undesirable paths in the T&C and credential handling code (especially when not in an interactive session), so I've added better support for when things go wrong there as well.