### PR TITLE
Updates error handling in GetSports, GetLine, and PlaceBet, plus more test code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,3 +20,4 @@ Imports:
     jsonlite,
     rjson
 RoxygenNote: 6.0.1
+Suggests: testthat, yaml

--- a/R/GetFixtures.R
+++ b/R/GetFixtures.R
@@ -56,6 +56,10 @@ GetFixtures <-
       stop("missing sport ID")
     }
 
+    if (length(sportid) > 1) {
+      stop("Only one sport can be specified at a time.")
+    }
+
     message(Sys.time(), "| Pulling Fixtures for Sport ID: ", sportid,
             if (!is.null(leagueids)) paste(", with League ID(s):",
                                            paste(leagueids, collapse = ", ")),

--- a/R/GetLine.R
+++ b/R/GetLine.R
@@ -71,23 +71,22 @@ GetLine <- function(sportid, leagueids, eventid,
     if (!is.null(handicap)) sprintf(' handicap: %s', handicap),
     ' oddsFormat: ', oddsFormat
   )
-  
-  r <- sprintf('%s/v1/line', .PinnacleAPI$url) %>%
-    modify_url(
-      query = list(sportId = sportid,
-                   leagueId = paste(leagueids, collapse = ','),
-                   eventId = eventid,
-                   periodNumber = periodnumber,
-                   betType = betType,
-                   team = team,
-                   side = side,
-                   handicap = handicap,
-                   oddsFormat = oddsFormat)
-      ) %>%
-    GET(add_headers(Authorization = authorization(),
-                    "Content-Type" = "application/json")) %>%
-    content(type = 'text', encoding = "UTF-8") %>%
-    jsonlite::fromJSON()
-  
-  return(r)
+
+  response <- httr::GET(paste0(.PinnacleAPI$url, "/v1/line"),
+                        httr::add_headers(Authorization = authorization()),
+                        httr::accept_json(),
+                        query = list(sportId = sportid,
+                                     leagueId = leagueids,
+                                     eventId = eventid,
+                                     periodNumber = periodnumber,
+                                     betType = betType,
+                                     team = team,
+                                     side = side,
+                                     handicap = handicap,
+                                     oddsFormat = oddsFormat))
+
+  CheckForAPIErrors(response)
+
+  response <- httr::content(response, type = "text", encoding = "UTF-8")
+  jsonlite::fromJSON(response)
 }

--- a/R/GetSports.R
+++ b/R/GetSports.R
@@ -25,21 +25,17 @@ GetSports <-
     # If Force = FALSE or the SportList is Empty then load a new Sport List
     if (length(.PinnacleAPI$sports) == 0 || force) {
       
-      message(
-        Sys.time(),
-        '| Pulling Sports'
-      )
-      
-      sprintf("%s/v2/sports",.PinnacleAPI$url) %>%
-        GET(add_headers("Authorization" = authorization())) %>%
-        content(type = 'text', encoding = "UTF-8") %>%
-        jsonlite::fromJSON() %>%
-        .[['sports']] %T>%
-        {
-          .PinnacleAPI$sports <- .
-        }
+      message(Sys.time(), "| Pulling Sports")
+
+      response <- httr::GET(paste0(.PinnacleAPI$url, "/v2/sports"),
+                            httr::add_headers(Authorization = authorization()),
+                            httr::accept_json())
+
+      CheckForAPIErrors(response)
+
+      response <- httr::content(response, type = "text", encoding = "UTF-8")
+      .PinnacleAPI$sports <- jsonlite::fromJSON(response)$sports
     }
-    
+
     .PinnacleAPI$sports
   }
-

--- a/R/PlaceBet.R
+++ b/R/PlaceBet.R
@@ -47,9 +47,6 @@
 #'   \item{errorCode}
 #' }
 #' @export
-#' @import httr
-#' @importFrom rjson toJSON
-#' @import uuid
 #' @examples
 #' \donttest{
 #' SetCredentials("TESTAPI","APITEST")
@@ -92,17 +89,30 @@ function (
     if (!is.null(acceptBetterLine)) sprintf(' acceptBetterLine: %s ', acceptBetterLine),
     ' oddsformat: ', oddsFormat
   )
-  
-  place_bet_data <- list(uniqueRequestId = UUIDgenerate(), 
-                         acceptBetterLine = acceptBetterLine, oddsFormat = oddsFormat, 
-                         stake = stake, winRiskStake = winRiskStake, sportId = sportId, 
-                         eventId = eventId, periodNumber = periodNumber, betType = betType, 
-                         lineId = lineId, altLineId = altLineId, team = team, 
-                         side = side)
-  place_bet_body <- rjson::toJSON(place_bet_data)
-  r <- httr::POST(paste0(.PinnacleAPI$url, "/v1/bets/place"), add_headers(Authorization = authorization(), 
-                                                                    `Content-Type` = "application/json"), 
-                  body = place_bet_body)
-  
-  jsonlite::fromJSON(content(r, type = "text", encoding = "UTF-8"))
+
+  bet <- list(uniqueRequestId = uuid::UUIDgenerate(),
+              acceptBetterLine = acceptBetterLine,
+              oddsFormat = oddsFormat,
+              stake = stake,
+              winRiskStake = winRiskStake,
+              sportId = sportId,
+              eventId = eventId,
+              periodNumber = periodNumber,
+              betType = betType,
+              lineId = lineId,
+              altLineId = altLineId,
+              team = team,
+              side = side)
+
+  request_body <- rjson::toJSON(bet)
+  response <- httr::POST(paste0(.PinnacleAPI$url, "/v1/bets/place"),
+                         httr::add_headers(Authorization = authorization(),
+                                           `Content-Type` = "application/json"),
+                         httr::accept_json(),
+                         body = request_body)
+
+  CheckForAPIErrors(response)
+
+  response <- httr::content(response, type = "text", encoding = "UTF-8")
+  jsonlite::fromJSON(response)
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,5 @@
+library(testthat)
+library(yaml)
+library(pinnacle.API)
+
+test_check("pinnacle.API")

--- a/tests/testthat/test-basic-functionality.R
+++ b/tests/testthat/test-basic-functionality.R
@@ -48,3 +48,43 @@ testthat::test_that("GetBettingStatus() returns the expected format", {
                                       "ALL_LIVE_BETTING_CLOSED",
                                       "ALL_BETTING_CLOSED"))
 })
+
+# Straight Lines --------------------------------------------------------------
+testthat::context("Straight Lines")
+
+testthat::test_that("GetFixtures() returns the expected format", {
+  fixtures <- pinnacle.API::GetFixtures(config$sport)
+
+  testthat::expect_is(fixtures, "data.frame")
+  testthat::expect_gt(nrow(fixtures), 0)
+
+  # Pick some events to test filtering calls against.
+  set.seed(101)
+  events <- sample.int(nrow(fixtures), 2)
+  events <- fixtures[events, c("league.id", "league.events.id")]
+  names(events) <- c("league", "event")
+
+  result <- pinnacle.API::GetFixtures(config$sport, eventids = events$event)
+  testthat::expect_equal(nrow(result), 2)
+
+  # Mismatched league/event IDs should give no results.
+  result <- pinnacle.API::GetFixtures(config$sport, eventids = events$event[1],
+                                      leagueids = events$league[1] + 1)
+  testthat::expect_equal(nrow(result), 0)
+
+  # Adding an invalid event ID should error.
+  testthat::expect_error(
+    pinnacle.API::GetFixtures(config$sport, eventids = c(-1, events$event)),
+    regexp = "Invalid request parameters."
+  )
+
+  # As should the addition of a second sport.
+  testthat::expect_error(
+    pinnacle.API::GetFixtures(c(config$sport, 1e6), eventids = events$event),
+    regexp = "Only one sport can be specified at a time."
+  )
+
+  # Some odd event IDs are allowed, though.
+  result <- pinnacle.API::GetFixtures(config$sport, eventids = 0)
+  testthat::expect_equal(nrow(result), 0)
+})

--- a/tests/testthat/test-basic-functionality.R
+++ b/tests/testthat/test-basic-functionality.R
@@ -1,0 +1,50 @@
+# Read test server/account parameters from a YAML file, so that they can be
+# kept out of the sources.
+config <- yaml::read_yaml("test_config.yaml")
+
+incomplete_config <- function() {
+  any(sapply(config, is.null))
+}
+
+if (!incomplete_config()) {
+  pinnacle.API::AcceptTermsAndConditions(TRUE)
+  pinnacle.API::SetCredentials(config$username, config$password)
+  pinnacle.API::SetAPIEndpoint(config$url)
+}
+
+# Basic API Functionality -----------------------------------------------------
+testthat::context("Basic API Functionality")
+
+testthat::skip_if(incomplete_config(), "Incomplete test configuration file.")
+
+testthat::test_that("API calls fail when terms are not explicitly accepted", {
+  pinnacle.API::AcceptTermsAndConditions(FALSE)
+  on.exit(pinnacle.API::AcceptTermsAndConditions(TRUE))
+
+  testthat::expect_error(
+    pinnacle.API::AcceptTermsAndConditions("invalid"),
+    regexp = "is not TRUE"
+  )
+
+  testthat::expect_error(
+    pinnacle.API::GetBettingStatus(),
+    regexp = "Error: please accept terms and conditions to continue"
+  )
+})
+
+testthat::test_that("API calls fail on invalid credentials", {
+  pinnacle.API::SetCredentials(config$username, "badpassword")
+  on.exit(pinnacle.API::SetCredentials(config$username, config$password))
+
+  testthat::expect_error(
+    pinnacle.API::GetBettingStatus(),
+    regexp = "Authorization failed, invalid credentials."
+  )
+})
+
+testthat::test_that("GetBettingStatus() returns the expected format", {
+  status <- pinnacle.API::GetBettingStatus()
+  testthat::expect_true(status %in% c("ALL_BETTING_ENABLED",
+                                      "ALL_LIVE_BETTING_CLOSED",
+                                      "ALL_BETTING_CLOSED"))
+})

--- a/tests/testthat/test-basic-functionality.R
+++ b/tests/testthat/test-basic-functionality.R
@@ -147,3 +147,54 @@ testthat::test_that("GetLine() returns the expected format", {
   testthat::expect_is(line, "list")
   testthat::expect_true(line$status %in% c("SUCCESS", "NOT_EXISTS", "OFFLINE"))
 })
+
+# Straight Lines --------------------------------------------------------------
+testthat::context("Straight Bets")
+
+testthat::test_that("PlaceBet() returns the expected format", {
+  # Some odd parameter combinations succeed.
+
+  bet <- pinnacle.API::PlaceBet(100, config$sport, eventId = 1, periodNumber = 0,
+                                lineId = 1, betType = "MONEYLINE", team = "TEAM1")
+
+  testthat::expect_is(bet, "list")
+  testthat::expect_equal(bet$status, "PROCESSED_WITH_ERROR")
+
+  bet <- pinnacle.API::PlaceBet(100, -config$sport, eventId = 1, periodNumber = 0,
+                                lineId = 1, betType = "MONEYLINE", team = "TEAM1")
+
+  testthat::expect_is(bet, "list")
+  testthat::expect_equal(bet$status, "PROCESSED_WITH_ERROR")
+
+  bet <- pinnacle.API::PlaceBet(100, config$sport, eventId = 1, periodNumber = -1,
+                                lineId = 1, betType = "MONEYLINE", team = "TEAM1")
+
+  testthat::expect_is(bet, "list")
+  testthat::expect_equal(bet$status, "PROCESSED_WITH_ERROR")
+
+  # Others are forbidden.
+
+  testthat::expect_error(
+    pinnacle.API::PlaceBet(100, config$sport, eventId = -1, periodNumber = 0,
+                           lineId = 1, betType = "MONEYLINE", team = "TEAM1"),
+    regexp = "Invalid eventId parameter value."
+  )
+
+  testthat::expect_error(
+    pinnacle.API::PlaceBet(-100, config$sport, eventId = 1, periodNumber = 0,
+                           lineId = 1, betType = "MONEYLINE", team = "TEAM1"),
+    regexp = "Invalid stake."
+  )
+
+  testthat::expect_error(
+    pinnacle.API::PlaceBet(100, config$sport, eventId = 1, periodNumber = 0,
+                           lineId = -1, betType = "MONEYLINE", team = "TEAM1"),
+    regexp = "Invalid lineId parameter value."
+  )
+
+  testthat::expect_error(
+    pinnacle.API::PlaceBet(100, config$sport, eventId = 1, periodNumber = 0,
+                           lineId = 1, betType = "MONEYLINE", team = NULL),
+    regexp = "The Team is required."
+  )
+})

--- a/tests/testthat/test-basic-functionality.R
+++ b/tests/testthat/test-basic-functionality.R
@@ -49,6 +49,21 @@ testthat::test_that("GetBettingStatus() returns the expected format", {
                                       "ALL_BETTING_CLOSED"))
 })
 
+testthat::test_that("GetSports() returns the expected format", {
+  sports <- pinnacle.API::GetSports(force = TRUE)
+  testthat::expect_is(sports, "data.frame")
+  testthat::expect_gt(nrow(sports), 0)
+})
+
+testthat::test_that("GetSports() caches correctly", {
+  pinnacle.API::GetSports(force = FALSE)  # Ensure cache is present.
+  pinnacle.API::SetCredentials(config$username, "badpassword")
+  on.exit(pinnacle.API::SetCredentials(config$username, config$password))
+
+  sports <- pinnacle.API::GetSports(force = FALSE)
+  testthat::expect_gt(nrow(sports), 0)
+})
+
 # Straight Lines --------------------------------------------------------------
 testthat::context("Straight Lines")
 

--- a/tests/testthat/test_config.yaml
+++ b/tests/testthat/test_config.yaml
@@ -1,3 +1,4 @@
 username:
 password:
 url:
+sport:

--- a/tests/testthat/test_config.yaml
+++ b/tests/testthat/test_config.yaml
@@ -1,0 +1,3 @@
+username:
+password:
+url:


### PR DESCRIPTION
This PR ports the `GetSports()`, `GetLine()`, and `PlaceBet()` functions to the new error handling pattern, following up on #27 and #26.

This PR builds on #28, since it includes new tests as well -- please **do not merge it** until #28 has been merged.