### PR TITLE
Adds support for the event ID parameter to GetOdds and showOddsDF

### DIFF
--- a/R/GetOdds.R
+++ b/R/GetOdds.R
@@ -34,14 +34,16 @@ GetOdds <-
            tableformat = 'mainlines',
            force = TRUE){
     CheckTermsAndConditions()
-    
-    ## retrieve sportid
-    if (missing(sportid)) {
+
+    # In interactive mode, try to retrieve a missing sportid parameter.
+    if(interactive() && missing(sportid)) {
       cat('No Sports Selected, choose one:\n')
       ViewSports()
       sportid <- readline('Selection (id): ')
+    } else if (missing(sportid)) {
+      stop("missing sport ID")
     }
-    
+
     message(
       Sys.time(),
       '| Pulling Odds for - sportid: ', sportid,

--- a/R/showOddsDF.R
+++ b/R/showOddsDF.R
@@ -1,38 +1,52 @@
-#' showOddsDF - Takes a GetOdds JSON response and combines with Fixtures and Inrunning
+#' Combine Odds, Fixture, and In-Running Information into a Single Data Frame
 #'
-#' @param sportid (optional) The sportid to get odds from, if none is given, 
-#' a list of options and a prompt are provided
-#' @param leagueids numeric vector of leagueids - can get as output from GetLeagues
-#' @param since numeric This is used to receive incremental updates. this will give all lines that have changed odds.
-#' @param islive boolean if TRUE retrieves ONLY live events
-#' @param force boolean default set to TRUE, forces a reload of the cache.
-#' @param tableformat 
-#' \itemize{
-#' \item 'mainlines' (default), only shows mainlines
-#' \item 'long' for a single record for each spread/total on an event, 
-#' \item 'wide' for all lines as one record, 
-#' \item 'subtables' all lines for spreads/totals stored as nested tables
-#' } 
-#' @param namesLength how many identifiers to use in the names, default is 3
-#' @param attachLeagueInfo whether or not to include league information in the data
-#' @param oddsformat default AMERICAN, see API manual for more options
-#' bettable leagues
-#' @param fixtures_since if set, get only fixtures that were posted since last.
-#' @return a dataframe combining GetOdds and GetFixtures data, containing NA's where levels of factors do not have a value.
-#' Naming convention is as follows, Example: spread.altLineId.N is the altLineId associated with spread.hdp.(N+1) 
-#' whereas spread.hdp refers to the mainline. spread.altLineId is the first alternate, and equivalent to spread.altLineId.0
-#' @export
-#' @import httr
-#' @import data.table
+#' Queries the event listing for a given sport and the odds offered on each
+#' event. This query can be filtered by league and/or event ID, and narrowed to
+#' include only live events.
+#'
+#' @param sportid An integer giving the sport. If this is missing in
+#'   interactive mode, a menu of options is presented to the user.
+#' @param leagueids A vector of league IDs, or \code{NULL}.
+#' @param eventids A vector of event IDs, or \code{NULL}.
+#' @param since Used to receive incremental odds updates. See
+#'   \code{\link{GetOdds}}.
+#' @param islive When \code{TRUE}, retrieve only live events.
+#' @param force Currently ignored.
+#' @param tableformat The format of the odds. See \code{\link{GetOdds}}.
+#' @param namesLength The number of identifiers to use in the names.
+#' @param attachLeagueInfo When \code{TRUE}, include league information in the
+#'   data.
+#' @param oddsformat Format for the returned odds. See \code{\link{GetOdds}}.
+#' @param fixtures_since Used to receive incremental fixture updates. See
+#'   \code{\link{GetFixtures}}.
+#'
+#' @return
+#'
+#' A data frame combining odds and fixtures data, containing \code{NA}s where
+#' levels of factors do not have a value. Example of the naming convention:
+#' \code{spread.altLineId.N} is the \code{altLineId} associated with
+#' \code{spread.hdp.(N+1)}, whereas \code{spread.hdp} refers to the mainline.
+#' \code{spread.altLineId} is the first alternate, and equivalent to
+#' \code{spread.altLineId.0}.
+#'
 #' @examples
 #' \donttest{
 #' SetCredentials("TESTAPI","APITEST")
 #' AcceptTermsAndConditions(accepted=TRUE)
 #' # Run without arguments, it will prompt you for the sport
 #' showOddsDF()}
+#'
+#' @seealso
+#'
+#' See \code{\link{GetOdds}}, \code{\link{GetFixtures}}, and
+#' \code{\link{GetInrunning}} for the underlying API requests.
+#'
+#' @import data.table
+#' @export
 showOddsDF <- 
   function(sportid,
            leagueids=NULL,
+           eventids = NULL,
            since = NULL,
            islive = 0,
            force = TRUE,
@@ -54,6 +68,7 @@ showOddsDF <-
     # Get JSON of odds
     res <- GetOdds(sportid,
                    leagueids = leagueids,
+                   eventids = eventids,
                    since = since,
                    islive = islive,
                    tableformat = tableformat,
@@ -67,6 +82,7 @@ showOddsDF <-
     # Get additional matchup details
     fixtures <- GetFixtures(sportid,
                             leagueids,
+                            eventids = eventids,
                             since  = fixtures_since,
                             islive = islive)
     

--- a/man/GetOdds.Rd
+++ b/man/GetOdds.Rd
@@ -2,37 +2,52 @@
 % Please edit documentation in R/GetOdds.R
 \name{GetOdds}
 \alias{GetOdds}
-\title{Get Odds}
+\title{Get Odds for Non-Settled Events in a Given Sport}
 \usage{
-GetOdds(sportid, leagueids = NULL, since = NULL, islive = 0,
-  oddsformat = "AMERICAN", tableformat = "mainlines", force = TRUE)
+GetOdds(sportid, leagueids = NULL, eventids = NULL, since = NULL,
+  islive = 0, oddsformat = "AMERICAN", tableformat = "mainlines",
+  force = TRUE)
 }
 \arguments{
-\item{sportid}{(optional) The sport id for which to retrieve the fixutres}
+\item{sportid}{An integer giving the sport. If this is missing in
+interactive mode, a menu of options is presented to the user.}
 
-\item{leagueids}{(optional) integer vector of leagueids.}
+\item{leagueids}{A vector of league IDs, or \code{NULL}.}
 
-\item{since}{(optional) numeric This is used to receive incremental updates.
-Use the value of last from previous response.}
+\item{eventids}{A vector of event IDs, or \code{NULL}.}
 
-\item{islive}{boolean if TRUE retrieves ONLY live events}
+\item{since}{To receive only listings updated since the last query, set
+\code{since} to the value of \code{last} from the previous fixtures
+response. Otherwise it will query all listings.}
 
-\item{oddsformat}{default AMERICAN, see API manual for more options}
+\item{islive}{When \code{TRUE}, retrieve only live events.}
 
-\item{tableformat}{\itemize{
-\item 'mainlines' (default), only shows mainlines
-\item 'long' for a single record for each spread/total on an event, 
-\item 'wide' for all lines as one record, 
-\item 'subtables' all lines for spreads/totals stored as nested tables
+\item{oddsformat}{Format for the returned odds. One of \code{"AMERICAN"},
+\code{"DECIMAL"}, \code{"HONGKONG"}, \code{"INDONESIAN"}, or
+\code{"MALAY"}.}
+
+\item{tableformat}{One of
+\itemize{
+  \item \code{"mainlines"} for mainlines only (the default);
+  \item \code{"long"} for a single record for each spread/total on an event; 
+  \item \code{"wide"} for all lines as one record; or
+  \item \code{"subtables"} all lines for spreads/totals stored as nested
+    tables.
 }}
 
-\item{force}{boolean if FALSE, functions using cached data will use the values since the last force}
+\item{force}{Currently ignored.}
 }
 \value{
-data.frame of odds
+A data frame of odds.
 }
 \description{
-Get Odds
+Queries all odds offered for a given sport, which can be filtered by league
+and/or event ID, and narrowed to include only live events.
+}
+\details{
+This function will raise an error if the API does not return HTTP status
+\code{OK}. For information on the possible errors, see the API documentation
+for \href{https://pinnacleapi.github.io/#operation/Odds_Straight_V1_Get}{Get Odds}.
 }
 \examples{
 \donttest{
@@ -40,4 +55,5 @@ SetCredentials("TESTAPI","APITEST")
 AcceptTermsAndConditions(accepted = TRUE)
 # We can run without parameters, and will be given a selection of sports
 GetOdds()}
+
 }

--- a/man/showOddsDF.Rd
+++ b/man/showOddsDF.Rd
@@ -2,47 +2,51 @@
 % Please edit documentation in R/showOddsDF.R
 \name{showOddsDF}
 \alias{showOddsDF}
-\title{showOddsDF - Takes a GetOdds JSON response and combines with Fixtures and Inrunning}
+\title{Combine Odds, Fixture, and In-Running Information into a Single Data Frame}
 \usage{
-showOddsDF(sportid, leagueids = NULL, since = NULL, islive = 0,
-  force = TRUE, tableformat = "mainlines", namesLength = 3,
+showOddsDF(sportid, leagueids = NULL, eventids = NULL, since = NULL,
+  islive = 0, force = TRUE, tableformat = "mainlines", namesLength = 3,
   attachLeagueInfo = TRUE, oddsformat = "AMERICAN", fixtures_since = NULL)
 }
 \arguments{
-\item{sportid}{(optional) The sportid to get odds from, if none is given, 
-a list of options and a prompt are provided}
+\item{sportid}{An integer giving the sport. If this is missing in
+interactive mode, a menu of options is presented to the user.}
 
-\item{leagueids}{numeric vector of leagueids - can get as output from GetLeagues}
+\item{leagueids}{A vector of league IDs, or \code{NULL}.}
 
-\item{since}{numeric This is used to receive incremental updates. this will give all lines that have changed odds.}
+\item{eventids}{A vector of event IDs, or \code{NULL}.}
 
-\item{islive}{boolean if TRUE retrieves ONLY live events}
+\item{since}{Used to receive incremental odds updates. See
+\code{\link{GetOdds}}.}
 
-\item{force}{boolean default set to TRUE, forces a reload of the cache.}
+\item{islive}{When \code{TRUE}, retrieve only live events.}
 
-\item{tableformat}{\itemize{
-\item 'mainlines' (default), only shows mainlines
-\item 'long' for a single record for each spread/total on an event, 
-\item 'wide' for all lines as one record, 
-\item 'subtables' all lines for spreads/totals stored as nested tables
-}}
+\item{force}{Currently ignored.}
 
-\item{namesLength}{how many identifiers to use in the names, default is 3}
+\item{tableformat}{The format of the odds. See \code{\link{GetOdds}}.}
 
-\item{attachLeagueInfo}{whether or not to include league information in the data}
+\item{namesLength}{The number of identifiers to use in the names.}
 
-\item{oddsformat}{default AMERICAN, see API manual for more options
-bettable leagues}
+\item{attachLeagueInfo}{When \code{TRUE}, include league information in the
+data.}
 
-\item{fixtures_since}{if set, get only fixtures that were posted since last.}
+\item{oddsformat}{Format for the returned odds. See \code{\link{GetOdds}}.}
+
+\item{fixtures_since}{Used to receive incremental fixture updates. See
+\code{\link{GetFixtures}}.}
 }
 \value{
-a dataframe combining GetOdds and GetFixtures data, containing NA's where levels of factors do not have a value.
-Naming convention is as follows, Example: spread.altLineId.N is the altLineId associated with spread.hdp.(N+1) 
-whereas spread.hdp refers to the mainline. spread.altLineId is the first alternate, and equivalent to spread.altLineId.0
+A data frame combining odds and fixtures data, containing \code{NA}s where
+levels of factors do not have a value. Example of the naming convention:
+\code{spread.altLineId.N} is the \code{altLineId} associated with
+\code{spread.hdp.(N+1)}, whereas \code{spread.hdp} refers to the mainline.
+\code{spread.altLineId} is the first alternate, and equivalent to
+\code{spread.altLineId.0}.
 }
 \description{
-showOddsDF - Takes a GetOdds JSON response and combines with Fixtures and Inrunning
+Queries the event listing for a given sport and the odds offered on each
+event. This query can be filtered by league and/or event ID, and narrowed to
+include only live events.
 }
 \examples{
 \donttest{
@@ -50,4 +54,9 @@ SetCredentials("TESTAPI","APITEST")
 AcceptTermsAndConditions(accepted=TRUE)
 # Run without arguments, it will prompt you for the sport
 showOddsDF()}
+
+}
+\seealso{
+See \code{\link{GetOdds}}, \code{\link{GetFixtures}}, and
+\code{\link{GetInrunning}} for the underlying API requests.
 }


### PR DESCRIPTION
This also cleans up `GetOdds()` to use the new error handling paradigm and makes some quality of life improvements to the documentation for both functions. Since `GetFixtures()` supports event IDs already, this is a pretty small change to `showOddsDF()`.